### PR TITLE
Feature/pokemon type features

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ In this project we will apply machine learning to establish the TLN (Time, Locat
 ### Data Set
 #### Feature sources
 The data set which is used for the prediction consists out of different features, which need to be extracted from the [raw API data](http://pokedata.c4e3f8c7.svc.dockerapp.io:65014/doc/#api-PokemonSighting-GetAllSightings) of Team A. To generate those features different feature sources are used. Each feature source provides different data, for example,
-- one source extracts the S2 cell id's from the raw API data by using it's latitude and longitude
-- whereas another extracts local time, hour of the day and other time related features from the timestamp of the API data
+- one source extracts the S2 cell id's from the raw API data by using latitude and longitude
+- whereas another extracts local time, hour of the day and other time-related features from the timestamp of the API data
 - another source uses location and time to extract weather related features and so on...
 
 ##### getFeature Method
-To handle all feature sources in a generic way they have to provide the `getFeature(key, pokeEntry)` method. The method receives a unique key which refers to a feature, e.g. the `hourOfTheDay` feature, and it recieves a pokeEntry, which represents the JSON object that Team A uses to describe the sighting of a Pokemon. The pokeEntry provides the following data:
+To handle all feature sources in a generic way they have to provide the `getFeature(key, pokeEntry)` method. The method receives a unique key which refers to a feature, e.g. the `hourOfTheDay` feature, and it receives a pokeEntry, which represents the JSON object that Team A uses to describe the sighting of a Pokemon. The pokeEntry provides the following data:
 
 ###### pokeEntry
 
@@ -30,7 +30,7 @@ To handle all feature sources in a generic way they have to provide the `getFeat
 }
 ```
 
-The latitude and longitude are actually added additonally, to allow easy access. Team A sends them in a nested JSON object within the pokeEntry.
+The latitude and longitude are actually added additionally, to allow easy access. Team A sends them in a nested JSON object within the pokeEntry.
 The same goes for appearedLocalTime.
 
 ###### Example feature source
@@ -65,6 +65,7 @@ The keys which are used in the `getFeature` method have to be specified in the `
       {
       "name": "API Features",
       "path": "./feature_sources/api_features.js",
+      "enabled": true,
       "features": [
         {
           "key": "pokemonId",
@@ -76,10 +77,11 @@ The keys which are used in the `getFeature` method have to be specified in the `
     {
       "name": "Time Features",
       "path": "./feature_sources/time_features.js",
+      "enabled": true,
       "features": [
         {
           "key": "hourOfTheDay",
-          "type": "numeric",
+          "type": "nominal",
           "enabled": true
         }
       ]
@@ -93,13 +95,14 @@ The config contains several feature sources, which can contain several features.
 A feature source needs to specify:
 - the relative `path` to the corresponding .js file
 - an arbitrary `name`
+- an `enabled` flag to indicate whether or not the features of the source should be included in the data set by specifying `true` or `false`.
 - a list of `features`.
 
 ###### Feature
 A feature is defined by:
 - a unique `key`, which can only be used once in the whole config file
-- a `type` which corresponds to the attribute type of weka, e.g. numeric, string or nominal. If nominal is provided the script creates a nominal list with all distinct values that exist in the data set. For example: `@ATTRIBUTE source {POKESNIPER, POKERADAR, TWITTER}`
-- an `enabled` flag to indicate whether or not the feature should be included in the data set, by specifing `true` or `false`.
+- a `type` which corresponds to the attribute type of Weka, e.g. numeric, string or nominal. If nominal is provided the script creates a nominal list with all distinct values that exist in the data set. For example: `@ATTRIBUTE source {POKESNIPER, POKERADAR, TWITTER}`
+- an `enabled` flag to indicate individually whether or not the feature should be included in the data set, by specifying `true` or `false`. The source must be enabled for that.
 
 ###### Class key
 The `classKey` defines which key will be used as classLabel when an .arff file is generated. The `classKey` has to correspond to a feature key in the configuration. If a feature key corresponds to the `classKey` it does not matter if the `enabled` flag is set or not. The script generates automatically a nominal list with all distinct values that exist in the data set for that key.

--- a/dataSet_creator.js
+++ b/dataSet_creator.js
@@ -153,8 +153,8 @@ var tzwhere = require('tzwhere');
      * @param pokeEntry the JSON object which is received from the API for a Pokemon sighting
      */
     function addCoordinatesToPokeEntry(pokeEntry) {
-        pokeEntry.latitude = pokeEntry["location"]["coordinates"][0];
-        pokeEntry.longitude = pokeEntry["location"]["coordinates"][1];
+        pokeEntry.latitude = pokeEntry["location"]["coordinates"][1];
+        pokeEntry.longitude = pokeEntry["location"]["coordinates"][0];
     }
 
 

--- a/dataSet_creator.js
+++ b/dataSet_creator.js
@@ -24,7 +24,7 @@ var tzwhere = require('tzwhere');
             var features = [];
             var isClassKeySource = false;
             source.features.forEach(function (feature) {
-                if (feature.enabled === true && feature.key !== config.classKey) {
+                if (source.enabled === true && feature.enabled === true && feature.key !== config.classKey) {
                     features.push(feature);
                 }
                 else if (feature.key === config.classKey) {

--- a/feature_config.json
+++ b/feature_config.json
@@ -126,6 +126,98 @@
           "enabled": true
         }
       ]
+    },
+    {
+      "name": "Pokemon Type Features",
+      "path": "./feature_sources/poketype_features.js",
+      "enabled": true,
+      "features": [
+        {
+          "key": "typeSteel",
+          "type": "nominal",
+          "enabled": true
+        },
+        {
+          "key": "typeGhost",
+          "type": "nominal",
+          "enabled": true
+        },
+        {
+          "key": "typeElectric",
+          "type": "nominal",
+          "enabled": true
+        },
+        {
+          "key": "typeIce",
+          "type": "nominal",
+          "enabled": true
+        },
+        {
+          "key": "typeNormal",
+          "type": "nominal",
+          "enabled": true
+        },
+        {
+          "key": "typeFire",
+          "type": "nominal",
+          "enabled": true
+        },
+        {
+          "key": "typePsychic",
+          "type": "nominal",
+          "enabled": true
+        },
+        {
+          "key": "typeFlying",
+          "type": "nominal",
+          "enabled": true
+        },
+        {
+          "key": "typePoison",
+          "type": "nominal",
+          "enabled": true
+        },
+        {
+          "key": "typeDragon",
+          "type": "nominal",
+          "enabled": true
+        },
+        {
+          "key": "typeWater",
+          "type": "nominal",
+          "enabled": true
+        },
+        {
+          "key": "typeFighting",
+          "type": "nominal",
+          "enabled": true
+        },
+        {
+          "key": "typeRock",
+          "type": "nominal",
+          "enabled": true
+        },
+        {
+          "key": "typeFairy",
+          "type": "nominal",
+          "enabled": true
+        },
+        {
+          "key": "typeGrass",
+          "type": "nominal",
+          "enabled": true
+        },
+        {
+          "key": "typeBug",
+          "type": "nominal",
+          "enabled": true
+        },
+        {
+          "key": "typeGround",
+          "type": "nominal",
+          "enabled": true
+        }
+      ]
     }
   ]
 }

--- a/feature_config.json
+++ b/feature_config.json
@@ -4,6 +4,7 @@
     {
       "name": "API Features",
       "path": "./feature_sources/api_features.js",
+      "enabled": true,
       "features": [
         {
           "key": "pokemonId",
@@ -45,6 +46,7 @@
     {
       "name": "S2 Features",
       "path": "./feature_sources/s2_features.js",
+      "enabled": true,
       "features": [
         {
           "key": "cellId_90m",
@@ -86,6 +88,7 @@
     {
       "name": "Time Features",
       "path": "./feature_sources/time_features.js",
+      "enabled": true,
       "features": [
         {
           "key": "appearedTimeOfDay",

--- a/feature_sources/poketype_features.js
+++ b/feature_sources/poketype_features.js
@@ -1,0 +1,76 @@
+var fs = require('fs');
+
+(function (exports) {
+    var module = exports.module = {};
+    var pokeTypes = fileToJson('json/pokemon_types.json');
+
+    /**
+     * Get the feature value for the specified key by using the data of the pokeEntry,
+     * which represents the JSON object which is returned from the API for a Pokemon sighting.
+     * @param key the name of the feature. The key is read out from the feature_config.json
+     * @param pokeEntry the JSON object which is received from the API for a Pokemon sighting
+     * @returns the value for the specified feature by considering the given data.
+     */
+    module.getFeature = function (key, pokeEntry) {
+        if(key === 'typeSteel') {
+            return pokeTypes[pokeEntry.pokemonId].indexOf('Steel') >= 0;
+        }
+        else if(key === 'typeGhost') {
+            return pokeTypes[pokeEntry.pokemonId].indexOf('Ghost') >= 0;
+        }
+        else if(key === 'typeElectric') {
+            return pokeTypes[pokeEntry.pokemonId].indexOf('Electric') >= 0;
+        }
+        else if(key === 'typeIce') {
+            return pokeTypes[pokeEntry.pokemonId].indexOf('Ice') >= 0;
+        }
+        else if(key === 'typeNormal') {
+            return pokeTypes[pokeEntry.pokemonId].indexOf('Normal') >= 0;
+        }
+        else if(key === 'typeFire') {
+            return pokeTypes[pokeEntry.pokemonId].indexOf('Fire') >= 0;
+        }
+        else if(key === 'typePsychic') {
+            return pokeTypes[pokeEntry.pokemonId].indexOf('Psychic') >= 0;
+        }
+        else if(key === 'typeFlying') {
+            return pokeTypes[pokeEntry.pokemonId].indexOf('Flying') >= 0;
+        }
+        else if(key === 'typePoison') {
+            return pokeTypes[pokeEntry.pokemonId].indexOf('Poison') >= 0;
+        }
+        else if(key === 'typeDragon') {
+            return pokeTypes[pokeEntry.pokemonId].indexOf('Dragon') >= 0;
+        }
+        else if(key === 'typeWater') {
+            return pokeTypes[pokeEntry.pokemonId].indexOf('Water') >= 0;
+        }
+        else if(key === 'typeFighting') {
+            return pokeTypes[pokeEntry.pokemonId].indexOf('Fighting') >= 0;
+        }
+        else if(key === 'typeRock') {
+            return pokeTypes[pokeEntry.pokemonId].indexOf('Rock') >= 0;
+        }
+        else if(key === 'typeFairy') {
+            return pokeTypes[pokeEntry.pokemonId].indexOf('Fairy') >= 0;
+        }
+        else if(key === 'typeGrass') {
+            return pokeTypes[pokeEntry.pokemonId].indexOf('Grass') >= 0;
+        }
+        else if(key === 'typeBug') {
+            return pokeTypes[pokeEntry.pokemonId].indexOf('Bug') >= 0;
+        }
+        else if(key === 'typeGround') {
+            return pokeTypes[pokeEntry.pokemonId].indexOf('Ground') >= 0;
+        }
+        else {
+            console.log("The key " + key + " is not handled by the type feature source.");
+            throw "UnknownFeatureKey";
+        }
+    };
+
+    function fileToJson(file) {
+        var data = fs.readFileSync(file, 'utf8');
+        return JSON.parse(data);
+    }
+})('undefined' !== typeof module ? module.exports : window);

--- a/json/pokemon_types.json
+++ b/json/pokemon_types.json
@@ -1,0 +1,522 @@
+{
+    "1": [
+        "Grass", 
+        "Poison"
+    ], 
+    "2": [
+        "Grass", 
+        "Poison"
+    ], 
+    "3": [
+        "Grass", 
+        "Poison"
+    ], 
+    "4": [
+        "Fire"
+    ], 
+    "5": [
+        "Fire"
+    ], 
+    "6": [
+        "Fire", 
+        "Flying"
+    ], 
+    "7": [
+        "Water"
+    ], 
+    "8": [
+        "Water"
+    ], 
+    "9": [
+        "Water"
+    ], 
+    "10": [
+        "Bug"
+    ], 
+    "11": [
+        "Bug"
+    ], 
+    "12": [
+        "Bug", 
+        "Flying"
+    ], 
+    "13": [
+        "Bug", 
+        "Poison"
+    ], 
+    "14": [
+        "Bug", 
+        "Poison"
+    ], 
+    "15": [
+        "Bug", 
+        "Poison"
+    ], 
+    "16": [
+        "Normal", 
+        "Flying"
+    ], 
+    "17": [
+        "Normal", 
+        "Flying"
+    ], 
+    "18": [
+        "Normal", 
+        "Flying"
+    ], 
+    "19": [
+        "Normal"
+    ], 
+    "20": [
+        "Normal"
+    ], 
+    "21": [
+        "Normal", 
+        "Flying"
+    ], 
+    "22": [
+        "Normal", 
+        "Flying"
+    ], 
+    "23": [
+        "Poison"
+    ], 
+    "24": [
+        "Poison"
+    ], 
+    "25": [
+        "Electric"
+    ], 
+    "26": [
+        "Electric"
+    ], 
+    "27": [
+        "Ground"
+    ], 
+    "28": [
+        "Ground"
+    ], 
+    "29": [
+        "Poison"
+    ], 
+    "30": [
+        "Poison"
+    ], 
+    "31": [
+        "Poison", 
+        "Ground"
+    ], 
+    "32": [
+        "Poison"
+    ], 
+    "33": [
+        "Poison"
+    ], 
+    "34": [
+        "Poison", 
+        "Ground"
+    ], 
+    "35": [
+        "Fairy"
+    ], 
+    "36": [
+        "Fairy"
+    ], 
+    "37": [
+        "Fire"
+    ], 
+    "38": [
+        "Fire"
+    ], 
+    "39": [
+        "Normal", 
+        "Fairy"
+    ], 
+    "40": [
+        "Normal", 
+        "Fairy"
+    ], 
+    "41": [
+        "Poison", 
+        "Flying"
+    ], 
+    "42": [
+        "Poison", 
+        "Flying"
+    ], 
+    "43": [
+        "Grass", 
+        "Poison"
+    ], 
+    "44": [
+        "Grass", 
+        "Poison"
+    ], 
+    "45": [
+        "Grass", 
+        "Poison"
+    ], 
+    "46": [
+        "Bug", 
+        "Grass"
+    ], 
+    "47": [
+        "Bug", 
+        "Grass"
+    ], 
+    "48": [
+        "Bug", 
+        "Poison"
+    ], 
+    "49": [
+        "Bug", 
+        "Poison"
+    ], 
+    "50": [
+        "Ground"
+    ], 
+    "51": [
+        "Ground"
+    ], 
+    "52": [
+        "Normal"
+    ], 
+    "53": [
+        "Normal"
+    ], 
+    "54": [
+        "Water"
+    ], 
+    "55": [
+        "Water"
+    ], 
+    "56": [
+        "Fighting"
+    ], 
+    "57": [
+        "Fighting"
+    ], 
+    "58": [
+        "Fire"
+    ], 
+    "59": [
+        "Fire"
+    ], 
+    "60": [
+        "Water"
+    ], 
+    "61": [
+        "Water"
+    ], 
+    "62": [
+        "Water", 
+        "Fighting"
+    ], 
+    "63": [
+        "Psychic"
+    ], 
+    "64": [
+        "Psychic"
+    ], 
+    "65": [
+        "Psychic"
+    ], 
+    "66": [
+        "Fighting"
+    ], 
+    "67": [
+        "Fighting"
+    ], 
+    "68": [
+        "Fighting"
+    ], 
+    "69": [
+        "Grass", 
+        "Poison"
+    ], 
+    "70": [
+        "Grass", 
+        "Poison"
+    ], 
+    "71": [
+        "Grass", 
+        "Poison"
+    ], 
+    "72": [
+        "Water", 
+        "Poison"
+    ], 
+    "73": [
+        "Water", 
+        "Poison"
+    ], 
+    "74": [
+        "Rock", 
+        "Ground"
+    ], 
+    "75": [
+        "Rock", 
+        "Ground"
+    ], 
+    "76": [
+        "Rock", 
+        "Ground"
+    ], 
+    "77": [
+        "Fire"
+    ], 
+    "78": [
+        "Fire"
+    ], 
+    "79": [
+        "Water", 
+        "Psychic"
+    ], 
+    "80": [
+        "Water", 
+        "Psychic"
+    ], 
+    "81": [
+        "Electric", 
+        "Steel"
+    ], 
+    "82": [
+        "Electric", 
+        "Steel"
+    ], 
+    "83": [
+        "Normal", 
+        "Flying"
+    ], 
+    "84": [
+        "Normal", 
+        "Flying"
+    ], 
+    "85": [
+        "Normal", 
+        "Flying"
+    ], 
+    "86": [
+        "Water"
+    ], 
+    "87": [
+        "Water", 
+        "Ice"
+    ], 
+    "88": [
+        "Poison"
+    ], 
+    "89": [
+        "Poison"
+    ], 
+    "90": [
+        "Water"
+    ], 
+    "91": [
+        "Water", 
+        "Ice"
+    ], 
+    "92": [
+        "Ghost", 
+        "Poison"
+    ], 
+    "93": [
+        "Ghost", 
+        "Poison"
+    ], 
+    "94": [
+        "Ghost", 
+        "Poison"
+    ], 
+    "95": [
+        "Rock", 
+        "Ground"
+    ], 
+    "96": [
+        "Psychic"
+    ], 
+    "97": [
+        "Psychic"
+    ], 
+    "98": [
+        "Water"
+    ], 
+    "99": [
+        "Water"
+    ], 
+    "100": [
+        "Electric"
+    ], 
+    "101": [
+        "Electric"
+    ], 
+    "102": [
+        "Grass", 
+        "Psychic"
+    ], 
+    "103": [
+        "Grass", 
+        "Psychic"
+    ], 
+    "104": [
+        "Ground"
+    ], 
+    "105": [
+        "Ground"
+    ], 
+    "106": [
+        "Fighting"
+    ], 
+    "107": [
+        "Fighting"
+    ], 
+    "108": [
+        "Normal"
+    ], 
+    "109": [
+        "Poison"
+    ], 
+    "110": [
+        "Poison"
+    ], 
+    "111": [
+        "Ground", 
+        "Rock"
+    ], 
+    "112": [
+        "Ground", 
+        "Rock"
+    ], 
+    "113": [
+        "Normal"
+    ], 
+    "114": [
+        "Grass"
+    ], 
+    "115": [
+        "Normal"
+    ], 
+    "116": [
+        "Water"
+    ], 
+    "117": [
+        "Water"
+    ], 
+    "118": [
+        "Water"
+    ], 
+    "119": [
+        "Water"
+    ], 
+    "120": [
+        "Water"
+    ], 
+    "121": [
+        "Water", 
+        "Psychic"
+    ], 
+    "122": [
+        "Psychic", 
+        "Fairy"
+    ], 
+    "123": [
+        "Bug", 
+        "Flying"
+    ], 
+    "124": [
+        "Ice", 
+        "Psychic"
+    ], 
+    "125": [
+        "Electric"
+    ], 
+    "126": [
+        "Fire"
+    ], 
+    "127": [
+        "Bug"
+    ], 
+    "128": [
+        "Normal"
+    ], 
+    "129": [
+        "Water"
+    ], 
+    "130": [
+        "Water", 
+        "Flying"
+    ], 
+    "131": [
+        "Water", 
+        "Ice"
+    ], 
+    "132": [
+        "Normal"
+    ], 
+    "133": [
+        "Normal"
+    ], 
+    "134": [
+        "Water"
+    ], 
+    "135": [
+        "Electric"
+    ], 
+    "136": [
+        "Fire"
+    ], 
+    "137": [
+        "Normal"
+    ], 
+    "138": [
+        "Rock", 
+        "Water"
+    ], 
+    "139": [
+        "Rock", 
+        "Water"
+    ], 
+    "140": [
+        "Rock", 
+        "Water"
+    ], 
+    "141": [
+        "Rock", 
+        "Water"
+    ], 
+    "142": [
+        "Rock", 
+        "Flying"
+    ], 
+    "143": [
+        "Normal"
+    ], 
+    "144": [
+        "Ice", 
+        "Flying"
+    ], 
+    "145": [
+        "Electric", 
+        "Flying"
+    ], 
+    "146": [
+        "Fire", 
+        "Flying"
+    ], 
+    "147": [
+        "Dragon"
+    ], 
+    "148": [
+        "Dragon"
+    ], 
+    "149": [
+        "Dragon", 
+        "Flying"
+    ], 
+    "150": [
+        "Psychic"
+    ], 
+    "151": [
+        "Psychic"
+    ]
+}


### PR DESCRIPTION
added binary features for each pokemon type #27 
All types and their count: 
- 'Ghost': 3,
- 'Ice': 5,
- 'Normal': 22,
- 'Grass': 14,
- 'Dragon': 3,
- 'Rock': 11,
- 'Bug': 12,
- 'Psychic': 14,
- 'Fighting': 8,
- 'Poison': 33,
- 'Electric': 9,
- 'Ground': 14,
- 'Fairy': 5,
- 'Fire': 12,
- 'Flying': 19,
- 'Steel': 2,
- 'Water': 32
