### PR TITLE
Is Pokemon Yes/No feature for given pokemonId

### DIFF
--- a/feature_config.json
+++ b/feature_config.json
@@ -1,5 +1,5 @@
 {
-  "classKey": "pokemonId",
+  "classKey": "isPokemonId_16",
   "feature_sources": [
     {
       "name": "API Features",
@@ -121,6 +121,18 @@
           "key": "appearedYear",
           "type": "numeric",
           "enabled": true
+        }
+      ]
+    },
+    {
+      "name": "Is Pokemon id Features",
+      "path": "./feature_sources/isPokemonId_features.js",
+      "enabled": true,
+      "features": [
+        {
+          "key": "isPokemonId_16",
+          "type": "nominal",
+          "enabled": false
         }
       ]
     }

--- a/feature_sources/isPokemonId_features.js
+++ b/feature_sources/isPokemonId_features.js
@@ -1,0 +1,27 @@
+(function (exports) {
+    var module = exports.module = {};
+
+    /**
+     * Get the feature value for the specified key by using the data of the pokeEntry,
+     * which represents the JSON object which is returned from the API for a Pokemon sighting.
+     * @param key the name of the feature. The key is read out from the feature_config.json
+     * @param pokeEntry the JSON object which is received from the API for a Pokemon sighting
+     * @returns the value for the specified feature by considering the given data.
+     */
+    module.getFeature = function (key, pokeEntry) {
+        var splitKey = key.split('_');
+
+        if (splitKey.length == 2 && splitKey[0] === "isPokemonId") {
+            if (pokeEntry.pokemonId == splitKey[1]) {
+                return 'isId' + splitKey[1];
+            }
+            else {
+                return 'otherId';
+            }
+        }
+        else {
+            console.log("The key " + key + " is not handled by the Is Pokemon feature source.");
+            throw "UnknownFeatureKey";
+        }
+    };
+})('undefined' !== typeof module ? module.exports : window);


### PR DESCRIPTION
added feature source to create class labels which indicate if an entry has the specified pokemonId or not

This feature source allows us to create e.g. the Pidgey dataset #20 by simply specifying the `isPokemonId_16` feature as classKey.
Furthermore, we can create a dataset for another Pokemon by changing the id 16 in the key, e.g. `isPokemonId_87`. Those modifications have only to be done in the config file. 

The `isPokemonId_*` feature is disabled, as it should be only used as a class label.
